### PR TITLE
Use combined method for darwin process lookups on darwin

### DIFF
--- a/process.go
+++ b/process.go
@@ -7,6 +7,8 @@
 // are interested.
 package ps
 
+import "fmt"
+
 // Process is the generic interface that is implemented on every platform
 // and provides common operations for processes.
 type Process interface {
@@ -43,3 +45,30 @@ func Processes() ([]Process, error) {
 func FindProcess(pid int) (Process, error) {
 	return findProcess(pid)
 }
+
+type matchFn func(Process) bool
+
+// findProcessesWithFn finds processes using match function.
+// If max is != 0, then we will return that max number of processes.
+func findProcessesWithFn(processesFn processesFn, matchFn matchFn, max int) ([]Process, error) {
+	processes, err := processesFn()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing processes: %s", err)
+	}
+	if processes == nil {
+		return nil, nil
+	}
+	procs := []Process{}
+	for _, p := range processes {
+		if matchFn(p) {
+			procs = append(procs, p)
+		}
+		if max != 0 && len(procs) >= max {
+			break
+		}
+	}
+	return procs, nil
+}
+
+// Avoid linting error
+var _ = findProcessesWithFn

--- a/process.go
+++ b/process.go
@@ -22,7 +22,8 @@ type Process interface {
 	// executable.
 	Executable() string
 
-	// Path is full path to the executable.
+	// Path is full path to the executable. The path may be unavailable if the
+	// exectuable was deleted from the system while it was still running.
 	Path() (string, error)
 }
 

--- a/process_darwin.c
+++ b/process_darwin.c
@@ -6,22 +6,67 @@
 #include <strings.h>
 #include <libproc.h>
 #include <unistd.h>
+#include <sys/sysctl.h>
 
 // This is declared in process_darwin.go
 extern void goDarwinAppendProc(pid_t, pid_t, char *);
+extern void goDarwinSetPath(pid_t, char *);
 
-// Loads the process table and calls the exported Go function to insert
-// the data back into the Go space.
+// darwinProcesses loads the process table and calls the exported Go function to
+// insert the data back into the Go space.
 //
 // This function is implemented in C because while it would technically
 // be possible to do this all in Go, I didn't want to go spelunking through
 // header files to get all the structures properly. It is much easier to just
 // call it in C and be done with it.
+int darwinProcesses() {
+    int err = 0;
+    int i = 0;
+    static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0 };
+    size_t length = 0;
+    struct kinfo_proc *result = NULL;
+    size_t resultCount = 0;
 
-void darwinProcesses() {
+    // Get the length first
+    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
+            NULL, &length, NULL, 0);
+    if (err != 0) {
+        goto ERREXIT;
+    }
 
-  uid_t euid = geteuid();
+    // Allocate the appropriate sized buffer to read the process list
+    result = malloc(length);
 
+    // Call sysctl again with our buffer to fill it with the process list
+    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
+            result, &length,
+            NULL, 0);
+    if (err != 0) {
+        goto ERREXIT;
+    }
+
+    resultCount = length / sizeof(struct kinfo_proc);
+    for (i = 0; i < resultCount; i++) {
+        struct kinfo_proc *single = &result[i];
+        goDarwinAppendProc(
+                single->kp_proc.p_pid,
+                single->kp_eproc.e_ppid,
+                single->kp_proc.p_comm);
+    }
+
+ERREXIT:
+    if (result != NULL) {
+        free(result);
+    }
+
+    if (err != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+// darwinProcessPaths looks up paths for process pids
+void darwinProcessPaths() {
   int pid_buf_size = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
   int pid_count = pid_buf_size / sizeof(pid_t);
 
@@ -31,23 +76,11 @@ void darwinProcesses() {
   proc_listpids(PROC_ALL_PIDS, 0, pids, pid_buf_size);
   char path_buffer[PROC_PIDPATHINFO_MAXSIZE];
 
-  int ppid = 0;
-
   for (int i=0; i < pid_count; i++) {
     if (pids[i] == 0) break;
-
-    if (euid == 0) {
-      // You need root permission to get proc_bsdinfo from some processes.
-      // When you call following function with normal user permission you will
-      // receive 'operation not permitted' error and it will be terminated.
-      struct proc_bsdinfo bsdinfo;
-      proc_pidinfo(pids[i], PROC_PIDTBSDINFO, 0, &bsdinfo, sizeof(struct proc_bsdinfo));
-      ppid = bsdinfo.pbi_ppid;
-    }
-
     bzero(path_buffer, PROC_PIDPATHINFO_MAXSIZE);
     if (proc_pidpath(pids[i], path_buffer, sizeof(path_buffer)) > 0) {
-      goDarwinAppendProc(pids[i], ppid, path_buffer);
+      goDarwinSetPath(pids[i], path_buffer);
     }
   }
   free(pids);

--- a/process_darwin_test.go
+++ b/process_darwin_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindProcessDarwin(t *testing.T) {
-	testFindProcess(t, "go-ps.test")
+	proc := testFindProcess(t, "go-ps.test")
+	assert.True(t, proc.PPid() > 0)
 }
 
 func TestProcessesDarwin(t *testing.T) {
@@ -27,17 +29,14 @@ func TestProcessesDarwinError(t *testing.T) {
 	assert.EqualError(t, err, "Error listing processes: oops")
 }
 
-func TestProcessExecRun(t *testing.T) {
-	testExecRun(t)
+func TestProcessExecRemoved(t *testing.T) {
+	procPath, cmd, proc := testExecRun(t)
+	defer cleanup(cmd, procPath)
+	t.Logf("Ran with PID: %d", cmd.Process.Pid)
+	// Remove it while it is running
+	_ = os.Remove(procPath)
+	matchPath := func(p Process) bool { return p.Pid() == proc.Pid() }
+	procs, err := findProcessesWithFn(processes, matchPath, 1)
+	require.NoError(t, err)
+	t.Logf("Proc: %#v", procs[0])
 }
-
-// TODO: Figure out how to get processes that have been removed
-// func TestProcessExecRemoved(t *testing.T) {
-// 	procPath, proc := testExecRun(t)
-// 	// Remove it while it is running
-// 	os.Remove(procPath)
-// 	matchPath := func(p Process) bool { return p.Pid() == proc.Pid() }
-// 	procs, err := findProcessesWithFn(processes, matchPath, 1)
-// 	require.NoError(t, err)
-// 	t.Logf("Proc: %#v", procs[0])
-// }

--- a/process_darwin_test.go
+++ b/process_darwin_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestFindProcessDarwin(t *testing.T) {
-	proc := testFindProcess(t, "go-ps.test")
-	assert.Equal(t, 0, proc.PPid())
+	testFindProcess(t, "go-ps.test")
 }
 
 func TestProcessesDarwin(t *testing.T) {
@@ -27,3 +26,18 @@ func TestProcessesDarwinError(t *testing.T) {
 	assert.Nil(t, proc)
 	assert.EqualError(t, err, "Error listing processes: oops")
 }
+
+func TestProcessExecRun(t *testing.T) {
+	testExecRun(t)
+}
+
+// TODO: Figure out how to get processes that have been removed
+// func TestProcessExecRemoved(t *testing.T) {
+// 	procPath, proc := testExecRun(t)
+// 	// Remove it while it is running
+// 	os.Remove(procPath)
+// 	matchPath := func(p Process) bool { return p.Pid() == proc.Pid() }
+// 	procs, err := findProcessesWithFn(processes, matchPath, 1)
+// 	require.NoError(t, err)
+// 	t.Logf("Proc: %#v", procs[0])
+// }

--- a/process_nix_test.go
+++ b/process_nix_test.go
@@ -85,6 +85,9 @@ func copyFile(sourcePath string, destinationPath string, mode os.FileMode) error
 
 func matchPath(t *testing.T, p Process, match string) bool {
 	path, err := p.Path()
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("Error trying to get path: %s", err)
+		return false
+	}
 	return path == match
 }

--- a/process_nix_test.go
+++ b/process_nix_test.go
@@ -1,0 +1,86 @@
+// +build darwin linux
+
+package ps
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testProcessPath(t *testing.T, procPath string) Process {
+	matchPath := func(p Process) bool {
+		return matchPath(t, p, procPath)
+	}
+	procs, err := findProcessesWithFn(processes, matchPath, 1)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(procs))
+	proc := procs[0]
+	path, err := proc.Path()
+	require.NoError(t, err)
+	require.Equal(t, procPath, path)
+	return proc
+}
+
+func cleanup(cmd *exec.Cmd, procPath string) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	_ = os.Remove(procPath)
+}
+
+func testExecPath(t *testing.T) string {
+	// Copy sleep executable to tmp
+	procPath := filepath.Join(os.TempDir(), "sleeptest")
+	err := copyFile("/bin/sleep", procPath, 0777)
+	require.NoError(t, err)
+	// Temp dir might have symlinks in which case we need the eval'ed path
+	procPath, err = filepath.EvalSymlinks(procPath)
+	require.NoError(t, err)
+	return procPath
+}
+
+func testExecRun(t *testing.T) (string, Process) {
+	procPath := testExecPath(t)
+	cmd := exec.Command(procPath, "10")
+	defer cleanup(cmd, procPath)
+	err := cmd.Start()
+	require.NoError(t, err)
+	proc := testProcessPath(t, procPath)
+	return procPath, proc
+}
+
+func copyFile(sourcePath string, destinationPath string, mode os.FileMode) error {
+	in, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(destinationPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, in)
+	closeErr := out.Close()
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(destinationPath, mode)
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func matchPath(t *testing.T, p Process, match string) bool {
+	path, err := p.Path()
+	require.NoError(t, err)
+	return path == match
+}

--- a/process_nix_test.go
+++ b/process_nix_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestProcessExecRun(t *testing.T) {
+	procPath, cmd, _ := testExecRun(t)
+	defer cleanup(cmd, procPath)
+}
+
 func testProcessPath(t *testing.T, procPath string) Process {
 	matchPath := func(p Process) bool {
 		return matchPath(t, p, procPath)
@@ -45,14 +50,13 @@ func testExecPath(t *testing.T) string {
 	return procPath
 }
 
-func testExecRun(t *testing.T) (string, Process) {
+func testExecRun(t *testing.T) (string, *exec.Cmd, Process) {
 	procPath := testExecPath(t)
 	cmd := exec.Command(procPath, "10")
-	defer cleanup(cmd, procPath)
 	err := cmd.Start()
 	require.NoError(t, err)
 	proc := testProcessPath(t, procPath)
-	return procPath, proc
+	return procPath, cmd, proc
 }
 
 func copyFile(sourcePath string, destinationPath string, mode os.FileMode) error {

--- a/process_unix.go
+++ b/process_unix.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -40,7 +41,7 @@ func (p *UnixProcess) Executable() string {
 
 // Path returns path to process executable
 func (p *UnixProcess) Path() (string, error) {
-	return "", fmt.Errorf("Unsupported")
+	return filepath.EvalSymlinks(fmt.Sprintf("/proc/%d/exe", p.pid))
 }
 
 // Refresh reloads all the data associated with this process.

--- a/process_unix_test.go
+++ b/process_unix_test.go
@@ -7,7 +7,3 @@ import "testing"
 func TestUnixProcess(t *testing.T) {
 	var _ Process = new(UnixProcess)
 }
-
-func TestProcessExecRun(t *testing.T) {
-	testExecRun(t)
-}

--- a/process_unix_test.go
+++ b/process_unix_test.go
@@ -7,3 +7,7 @@ import "testing"
 func TestUnixProcess(t *testing.T) {
 	var _ Process = new(UnixProcess)
 }
+
+func TestProcessExecRun(t *testing.T) {
+	testExecRun(t)
+}


### PR DESCRIPTION
This is so we can get parent pid and processes that have been deleted while running (on darwin), which proc_listpids doesn't give by itself.
