### PR TITLE
remove amd64 from build directive

### DIFF
--- a/process_openbsd.go
+++ b/process_openbsd.go
@@ -1,4 +1,4 @@
-// +build openbsd,amd64
+// +build openbsd
 
 package ps
 


### PR DESCRIPTION
The code works on both amd64 and i386 for OpenBSD, so let it build there too.
