### PR TITLE
Add netbsd build header to process_nix/unix

### DIFF
--- a/process_nix_test.go
+++ b/process_nix_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin linux netbsd
 
 package ps
 

--- a/process_unix.go
+++ b/process_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux netbsd
 
 package ps
 


### PR DESCRIPTION
On NetBSD we can take advantage of Linux Emulation so we have the procfs
mounted and simply use what Linux does.

This builds and the tests pass in the scenario.

I haven't yet been able to get the tests to pass by copying the
process_openbsd.go approach. If/when I do I will do that as a separate
branch.

References: https://github.com/dressupgeekout/keybase-client/commit/bccaaf3096a575589bb6ee8194008c34fe1f97c8
References: https://github.com/keybase/client/pull/19061